### PR TITLE
Fix tool when it's use as -g package

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,14 +9,14 @@ const packageJsonFile = editJsonFile('./package.json', { autosave: true });
 const devDependencies = packageJsonFile.get('devDependencies');
 const dependencies = packageJsonFile.get('dependencies');
 
-const hasChanges = false;
+let hasChanges = false;
 
 console.log('----------- Checking devDependencies versions -------------');
 
 const fixVersion = (namespace, dependencies) => {
   if (!isObject(dependencies)) return;
   Object.keys(dependencies).forEach(dependency => {
-    var version = dependencies[dependency];
+    const version = dependencies[dependency];
     if (versionSpecialCharacter.test(version)) {
       setDependency(namespace, dependency, version);
     }
@@ -62,4 +62,4 @@ const fixPackageModule = {
   }
 };
 
-exports.module = fixPackageModule;
+module.exports = fixPackageModule;


### PR DESCRIPTION
Hey there! I tried to use your lib to fix versions and it's works, but only when i go into sources and fix a couple of thing

Without this edits it throws an exception:
```bash
/***/.nvm/versions/node/v8.6.0/lib/node_modules/fix-package-versions/bin/fix-package-versions:12
  fixPackageVersions.areYouSure();
                     ^

TypeError: fixPackageVersions.areYouSure is not a function
    at Object.<anonymous> (/***/.nvm/versions/node/v8.6.0/lib/node_modules/fix-package-versions/bin/fix-package-versions:12:22)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
    at Function.Module.runMain (module.js:665:10)
    at startup (bootstrap_node.js:187:16)
    at bootstrap_node.js:607:3
```